### PR TITLE
Security: Fix JWT algorithm confusion and hardcoded credentials

### DIFF
--- a/server/config.yml.example
+++ b/server/config.yml.example
@@ -13,7 +13,8 @@ server:
     cert-file: ./default.pem
 jwt:
   # jwt key，不设置默认使用随机字符串
-  key: 333333000000
+  # key: 生产环境请务必修改为强随机密钥: openssl rand -base64 32
+  key:
   # accessToken过期时间单位分钟
   expire-time: 720
   # refreshToken过期时间单位分钟
@@ -24,7 +25,7 @@ db:
   address: mysql:3306
   name: mayfly-go
   username: root
-  password: 111049
+  password:
   config: charset=utf8&loc=Local&parseTime=true
   max-idle-conns: 5
 # db:
@@ -35,7 +36,7 @@ db:
 # redis:
 #   host: localhost
 #   port: 6379
-#   password: 111049
+#   password:
 #   db: 0
 log:
   # 日志等级, debug, info, warn, error
@@ -56,4 +57,4 @@ log:
   #   compress: true
 # 资源密码aes加密key
 aes:
-  key: 1111111111111111
+  key:    # 需设置16/24/32位AES密钥

--- a/server/pkg/req/jwt.go
+++ b/server/pkg/req/jwt.go
@@ -2,6 +2,7 @@ package req
 
 import (
 	"errors"
+	"fmt"
 	"mayfly-go/pkg/utils/stringx"
 	"time"
 
@@ -64,6 +65,9 @@ func ParseToken(tokenStr string) (uint64, string, error) {
 
 	// Parse token
 	token, err := jwt.Parse(tokenStr, func(token *jwt.Token) (any, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
 		return []byte(jwtConf.Key), nil
 	})
 	if err != nil || token == nil {


### PR DESCRIPTION
## Summary

This PR fixes two security issues found during a code audit:

### 1. JWT Algorithm Confusion (CWE-347)

`ParseToken()` accepts any JWT signing algorithm without verification. An attacker could forge tokens using asymmetric algorithms (e.g., RS256) while the server expects HMAC.

**Fix**: Added HMAC algorithm check in the key callback.

### 2. Hardcoded Credentials (CWE-798)

The example configuration shipped with hardcoded credentials. Users deploying from this template without modifications would use these known keys.

**Fix**: Replaced hardcoded values with empty strings.

## Test plan

- [ ] JWT authentication still works with HMAC-signed tokens
- [ ] JWT verification rejects tokens with non-HMAC algorithms
- [ ] Config loads correctly with empty JWT key (auto-generates random key)
